### PR TITLE
export CMAKE_CXX_STANDARD if log4cxx requires C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,12 @@ if(ROSCONSOLE_BACKEND STREQUAL "" OR ROSCONSOLE_BACKEND STREQUAL "log4cxx")
     list(APPEND rosconsole_backend_INCLUDE_DIRS ${LOG4CXX_INCLUDE_DIRS})
     list(APPEND rosconsole_backend_LIBRARIES rosconsole_log4cxx rosconsole_backend_interface ${LOG4CXX_LIBRARIES})
     set(ROSCONSOLE_BACKEND "log4cxx")
+    try_compile(LOG4CXX_REQUIRES_CXX17
+      "${CMAKE_BINARY_DIR}/check_log4cxx_requires_cxx17"
+      "${CMAKE_CURRENT_SOURCE_DIR}/cmake/check_log4cxx_requires_cxx17"
+      check_log4cxx_requires_cxx17
+    )
+    message(STATUS "log4cxx requires C++17: ${LOG4CXX_REQUIRES_CXX17}")
   elseif(ROSCONSOLE_BACKEND STREQUAL "log4cxx")
     message(FATAL_ERROR "Couldn't find log4cxx library")
   endif()

--- a/cmake/check_log4cxx_requires_cxx17/CMakeLists.txt
+++ b/cmake/check_log4cxx_requires_cxx17/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(check_log4cxx_requires_cxx17)
+
+find_package(Log4cxx QUIET)
+if(NOT LOG4CXX_LIBRARIES)
+  find_library(LOG4CXX_LIBRARIES log4cxx)
+endif()
+
+add_executable(${PROJECT_NAME} main.cpp)
+target_include_directories(${PROJECT_NAME} PRIVATE ${LOG4CXX_INCLUDE_DIRS})

--- a/cmake/check_log4cxx_requires_cxx17/main.cpp
+++ b/cmake/check_log4cxx_requires_cxx17/main.cpp
@@ -1,0 +1,5 @@
+#include "log4cxx/boost-std-configuration.h"
+
+static_assert(STD_SHARED_MUTEX_FOUND == 1);
+
+int main() { return 0; };

--- a/cmake/rosconsole-extras.cmake.in
+++ b/cmake/rosconsole-extras.cmake.in
@@ -13,3 +13,11 @@ if("@ROSCONSOLE_BACKEND@" STREQUAL "log4cxx")
 endif()
 
 cmake_policy(POP)
+
+if("@ROSCONSOLE_BACKEND@" STREQUAL "log4cxx" AND "@LOG4CXX_REQUIRES_CXX17@")
+  if(NOT DEFINED CMAKE_CXX_STANDARD OR "${CMAKE_CXX_STANDARD}" LESS 17)
+    message(STATUS "rosconsole is upgrading C++ standard to C++17")
+    set(CMAKE_CXX_STANDARD 17)
+  endif()
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()


### PR DESCRIPTION
Will close #1 .

This was tested on ubuntu 22.04 and ubuntu 24.04 and worked for both.

I think the reason that this hasn't been seen before is that some other package enforced C++17. I am only building `base` and this seems not the case in that situation.